### PR TITLE
Updated systemctl command + regex

### DIFF
--- a/systemd-service-status.py
+++ b/systemd-service-status.py
@@ -35,7 +35,7 @@ class SystemdServiceStatus:
         # Temporary data structure used to create sorted oid list later
         oids = [self.oid_prefix]
 
-        lines = subprocess.check_output(["/bin/systemctl", "list-units", "-a", "-t", "service", "--no-legend"]).decode("UTF-8").split("\n")
+        lines = subprocess.check_output(["/bin/systemctl", "list-units", "-a", "-t", "service", "--no-legend", "--plain"]).decode("UTF-8").split("\n")
 
         for line in lines:
             # Filter out systemd services that are service instance "templates" and
@@ -47,7 +47,7 @@ class SystemdServiceStatus:
                #
                # Regular expression can be easily tested online, e.g. here: https://pythex.org
                #
-               result = re.search(r"^(.+)\.service\s+[\w|-]+\s+\w+\s+(\w+)\s+.*$", line)
+               result = re.search(r"^(.+)\.service\s+[\w|-]+\s+\w+\s+([\w|-]+)\s+.*$", line)
                service_name = result.group(1)
                service_status = result.group(2)
 


### PR DESCRIPTION
Thanks for the script!
I found a couple of issues when testing and wanted to share the tweaks we made.

On some distros the "systemctl list-units" output contains an additional column to the left that can contain bullet points. This results in space and/or bullet characters being encoded as part of the OID. Adding "--plain" to the systemctl command prevents these bullets from being printed and interpreted as part of the service name.

Without "--plain" on Ubuntu 22.04
![image](https://github.com/Puppet-Finland/net-snmp-systemd-service-status/assets/146476524/5aebebd8-fc5c-41aa-8872-4bd3f3c6d6e7)

With "--plain" on Ubuntu 22.04
![image](https://github.com/Puppet-Finland/net-snmp-systemd-service-status/assets/146476524/88e017ca-c3c2-4ad4-9dfa-0ea903738587)

We also found that the sub-state for some services could be "auto-restart", which failed to match the existing regex because of the dash character. I've tweaked it to accept a dash.

We've tested the changes on AlmaLinux 8.8, CentOS 7, Debian 12, Kali Linux, Rocky Linux 9.2, openSUSE Leap 15.5, Ubuntu 18.04, and Ubuntu 22.04.